### PR TITLE
implement earth mode

### DIFF
--- a/MapGPT/app/globals.css
+++ b/MapGPT/app/globals.css
@@ -66,11 +66,37 @@
   }
 }
 
-@layer base {
-  * {
-    @apply border-border;
+  .earth {
+    --background: 34 35% 91%;
+    --foreground: 120 50% 30%;
+    
+    --card: 120 20% 80%;
+    --card-foreground: 120 25% 30%;
+
+    --popover: 34 35% 91%;
+    --popover-foreground: 34 35% 9%;
+
+    --primary: 120 50% 30%;
+    --primary-foreground: 34 60% 9%;
+
+    --secondary: 34 35% 75%;
+    --secondary-foreground: 52 21% 30%;
+
+    --muted: 34 35% 75%;
+    --muted-foreground: 52 21% 30%;
+
+    --accent: 34 35% 75%; 
+    --accent-foreground: 120 50% 30%; 
+
+    --destructive: 34 35% 9%;
+    --destructive-foreground: 34 60% 9%;
+
+    --border: 34 35% 75%;
+    --input: 34 35% 75%;
+    --ring: 34 35% 75%;
   }
+
   body {
-    @apply bg-background text-foreground;
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
   }
-}

--- a/MapGPT/app/layout.tsx
+++ b/MapGPT/app/layout.tsx
@@ -53,6 +53,7 @@ export default function RootLayout({
           defaultTheme="system"
           enableSystem
           disableTransitionOnChange
+          themes={['light', 'dark', 'earth']}
         >
           <Header />
           {children}

--- a/MapGPT/components/mode-toggle.tsx
+++ b/MapGPT/components/mode-toggle.tsx
@@ -31,6 +31,9 @@ export function ModeToggle() {
         <DropdownMenuItem onClick={() => setTheme('dark')}>
           Dark
         </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme('earth')}>
+          Earth
+        </DropdownMenuItem>
         <DropdownMenuItem onClick={() => setTheme('system')}>
           System
         </DropdownMenuItem>


### PR DESCRIPTION
resolves #26 and #27. images are included of the new earth theme in this description. 
<img width="1710" alt="Screenshot 2024-06-05 at 1 19 57 PM" src="https://github.com/QueueLab/MapGPT/assets/171291607/96d7b34f-cee9-48fe-a907-013a8edf3364">
<img width="1710" alt="Screenshot 2024-06-05 at 1 20 20 PM" src="https://github.com/QueueLab/MapGPT/assets/171291607/5a266b64-7a76-4bdf-9bd4-474df618c5fb">
<img width="1710" alt="Screenshot 2024-06-05 at 1 20 56 PM" src="https://github.com/QueueLab/MapGPT/assets/171291607/4b656c1c-17b2-4868-9ba6-1e18e314d9eb">
