### PR TITLE
Fix map footer boundary

### DIFF
--- a/MapGPT/components/footer.tsx
+++ b/MapGPT/components/footer.tsx
@@ -17,12 +17,12 @@ const Footer: React.FC = () => {
     >
       <div className="container mx-auto flex justify-between items-center">
         <div className="flex space-x-10">
-          <Link href="https://discord.com" passHref>
+          <Link href="https://discord.com/invite/WEPSzPbWtq" passHref>
             <Button variant="ghost" size="icon">
               <SiDiscord size={24} />
             </Button>
           </Link>
-          <Link href="https://github.com" passHref>
+          <Link href="https://github.com/QueueLab/MapGPT" passHref>
             <Button variant="ghost" size="icon">
               <SiGithub size={24} />
             </Button>

--- a/MapGPT/components/footer.tsx
+++ b/MapGPT/components/footer.tsx
@@ -5,7 +5,38 @@ import { Button } from './ui/button'
 
 const Footer: React.FC = () => {
   return (
-    <footer className="w-fit p-1 md:p-2 fixed bottom-0 right-0">
+    <footer
+      style={{
+        width: '100%',
+        height: '7.75%',
+        padding: '1rem 1.5rem',
+        position: 'fixed',
+        bottom: 0,
+        right: 0
+      }}
+    >
+      <div className="container mx-auto flex justify-between items-center">
+        <div className="flex space-x-10">
+          <Link href="https://discord.com" passHref>
+            <Button variant="ghost" size="icon">
+              <SiDiscord size={24} />
+            </Button>
+          </Link>
+          <Link href="https://github.com" passHref>
+            <Button variant="ghost" size="icon">
+              <SiGithub size={24} />
+            </Button>
+          </Link>
+          <Link href="https://twitter.com" passHref>
+            <Button variant="ghost" size="icon">
+              <SiTwitter size={24} />
+            </Button>
+          </Link>
+        </div>
+        <div className="w-1/2 left-justified p-4">
+          <p>&copy; {new Date().getFullYear()} Queue Enterprise. All rights reserved.</p>
+        </div>
+      </div>
     </footer>
   )
 }

--- a/MapGPT/components/footer.tsx
+++ b/MapGPT/components/footer.tsx
@@ -5,38 +5,7 @@ import { Button } from './ui/button'
 
 const Footer: React.FC = () => {
   return (
-    <footer
-      style={{
-        width: '100%',
-        height: '7.75%',
-        padding: '1rem 1.5rem',
-        position: 'fixed',
-        bottom: 0,
-        right: 0
-      }}
-    >
-      <div className="container mx-auto flex justify-between items-center">
-        <div className="flex space-x-10">
-          <Link href="https://discord.com/invite/WEPSzPbWtq" passHref>
-            <Button variant="ghost" size="icon">
-              <SiDiscord size={24} />
-            </Button>
-          </Link>
-          <Link href="https://github.com/QueueLab/MapGPT" passHref>
-            <Button variant="ghost" size="icon">
-              <SiGithub size={24} />
-            </Button>
-          </Link>
-          <Link href="https://twitter.com" passHref>
-            <Button variant="ghost" size="icon">
-              <SiTwitter size={24} />
-            </Button>
-          </Link>
-        </div>
-        <div className="w-1/2 left-justified p-4">
-          <p>&copy; {new Date().getFullYear()} Queue Enterprise. All rights reserved.</p>
-        </div>
-      </div>
+    <footer className="w-fit p-1 md:p-2 fixed bottom-0 right-0">
     </footer>
   )
 }

--- a/MapGPT/components/map/mapbox-map.tsx
+++ b/MapGPT/components/map/mapbox-map.tsx
@@ -55,6 +55,6 @@ export const Mapbox: React.FC = () => {
   }, []);
 
   return (
-    <div ref={mapContainer} className="h-full w-full overflow-hidden rounded-l-lg"/>
+    <div ref={mapContainer} style={{ height: '90%', width: '100%' }} className="overflow-hidden rounded-l-lg"/>
   );
 }


### PR DESCRIPTION
resolves #33 and includes a sample starter footer with clickable links to github, discord, and twitter. github and discord links pertain to this project in specific, twitter link redirects to https://twitter.com. i have included a screenshot of what this change looks like.
<img width="816" alt="Screenshot 2024-06-10 at 1 45 56 PM" src="https://github.com/QueueLab/MapGPT/assets/171291607/567d7886-b0c6-4030-b4b5-37a13fd72159">

